### PR TITLE
feat: Gmail로 인증 메일 발송하도록 변경

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,7 +3,7 @@
 	"collection": "@nestjs/schematics",
 	"sourceRoot": "src",
 	"compilerOptions": {
-		"assets": ["mail/templates/**/*"],
+		"assets": ["**/mail/templates/*"],
 		"watchAssets": true,
 		"plugins": ["@nestjs/swagger"]
 	}

--- a/src/configs/mail/mail.config.service.ts
+++ b/src/configs/mail/mail.config.service.ts
@@ -10,8 +10,9 @@ export class MailConfigService implements MailerOptionsFactory {
 	createMailerOptions(): MailerOptions | Promise<MailerOptions> {
 		return {
 			transport: {
-				host: this.configService.get<string>('EMAIL_HOST'),
-				port: this.configService.get<number>('EMAIL_PORT'),
+				service: this.configService.get<string>('EMAIL_SERVICE'),
+				// host: this.configService.get<string>('EMAIL_HOST'),
+				// port: this.configService.get<number>('EMAIL_PORT'),
 				secure: false,
 				auth: {
 					user: this.configService.get<string>('EMAIL_USERNAME'),
@@ -22,7 +23,7 @@ export class MailConfigService implements MailerOptionsFactory {
 				from: this.configService.get<string>('EMAIL_FROM'),
 			},
 			template: {
-				dir: `dist/mail/templates`,
+				dir: `dist/modules/mail/templates`,
 				adapter: new PugAdapter(),
 				options: {
 					strict: true,

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,14 +9,13 @@ import { MailModule } from 'src/modules/mail/mail.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { UserModule } from '../user/user.module';
-import { jwtConstants } from './constants';
 import { AdminModule } from '../admin/admin.module';
 
 @Module({
 	imports: [
 		PassportModule,
 		JwtModule.register({
-			secret: jwtConstants.secret,
+			secret: process.env.JWT_SECRET,
 			signOptions: { expiresIn: '12h' },
 		}),
 		UserModule,

--- a/src/modules/auth/constants.ts
+++ b/src/modules/auth/constants.ts
@@ -1,3 +1,0 @@
-export const jwtConstants = {
-	secret: 'keyboard cat',
-};

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Request } from 'express';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { jwtConstants } from '../constants';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -14,7 +13,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 				},
 			]),
 			ignoreExpiration: false,
-			secretOrKey: jwtConstants.secret,
+			secretOrKey: process.env.JWT_SECRET,
 		});
 	}
 

--- a/src/modules/auth/strategies/magic-login.strategy.ts
+++ b/src/modules/auth/strategies/magic-login.strategy.ts
@@ -14,7 +14,7 @@ export class MagicLoginStrategy extends PassportStrategy(
 		private authService: AuthService,
 	) {
 		super({
-			secret: 'helloworld',
+			secret: process.env.MAGIC_SECRET,
 			callbackUrl: 'auth/login/magic/callback',
 			sendMagicLink: async (destination, href) => {
 				await this.mailService.sendUserConfirmation(destination, href);

--- a/src/modules/mail/mail.service.ts
+++ b/src/modules/mail/mail.service.ts
@@ -9,7 +9,7 @@ export class MailService {
 		await this.mailerService.sendMail({
 			// from: mail.module 등록할 때 default로 입력함
 			to: userEmail,
-			subject: 'Welcome to Nice App! Confirm your Email',
+			subject: '온라인 명륜당 로그인',
 			template: './mail',
 			context: {
 				// ✏️ filling curly brackets with content

--- a/src/modules/mail/templates/mail.pug
+++ b/src/modules/mail/templates/mail.pug
@@ -1,4 +1,4 @@
-h1 this is title
+h1 온라인 명륜당
 h2= name
 p 
 	a(href=baseUrl + url) confirm

--- a/src/modules/seed/seed.service.ts
+++ b/src/modules/seed/seed.service.ts
@@ -18,7 +18,6 @@ import { Hashtag } from './seeds/hashtag.seed';
 import { Lecture } from './seeds/lecture.seed';
 import { User } from './seeds/user.seed';
 import { Admin } from './seeds/admin.seed';
-import { AdminEntity } from 'src/entities/admin.entity';
 import { Complete } from './seeds/complete.seed';
 import { CompleteEntity } from 'src/entities/complete.entity';
 import { HistoryEntity } from 'src/entities/history.entity';
@@ -42,8 +41,8 @@ export class SeedService {
 			{ seed: User, table: UserEntity },
 			{ seed: Complete, table: CompleteEntity },
 			{ seed: History, table: HistoryEntity },
-			{ seed: Wishlist, table: WishlistEntity},
-			{ seed: Learning, table: LearningEntity}
+			{ seed: Wishlist, table: WishlistEntity },
+			{ seed: Learning, table: LearningEntity },
 		];
 
 		if (true) {
@@ -65,9 +64,7 @@ export class SeedService {
 
 	async countData() {
 		return {
-			admin: await this.dataSource
-				.getRepository(AdminEntity)
-				.count(),
+			admin: await this.dataSource.getRepository(AdminEntity).count(),
 			category1: await this.dataSource
 				.getRepository(Category1Entity)
 				.count(),
@@ -80,27 +77,17 @@ export class SeedService {
 			complete: await this.dataSource
 				.getRepository(CompleteEntity)
 				.count(),
-			history: await this.dataSource
-        .getRepository(HistoryEntity)
-        .count(),
-			course: await this.dataSource
-				.getRepository(CourseEntity)
-				.count(),
-			hashtag: await this.dataSource
-				.getRepository(HashtagEntity)
-				.count(),
-			lecture: await this.dataSource
-				.getRepository(LectureEntity)
-				.count(),
-			user: await this.dataSource
-				.getRepository(UserEntity)
-				.count(),
+			history: await this.dataSource.getRepository(HistoryEntity).count(),
+			course: await this.dataSource.getRepository(CourseEntity).count(),
+			hashtag: await this.dataSource.getRepository(HashtagEntity).count(),
+			lecture: await this.dataSource.getRepository(LectureEntity).count(),
+			user: await this.dataSource.getRepository(UserEntity).count(),
 			wishlist: await this.dataSource
 				.getRepository(WishlistEntity)
 				.count(),
 			learning: await this.dataSource
 				.getRepository(LearningEntity)
-				.count()
+				.count(),
 		};
 	}
 


### PR DESCRIPTION
1) .env에 이메일 정보 입력 필요
    - EMAIL_SERVICE: gmail
    - EMAIL_USERNAME: 이메일 주소
    - EMAIL_PASSWORD: 구글 계정 비밀번호가 아니라 앱 비밀번호
    - EMAIL_FROM: 발신자 이름과 이메일 주소
2) 이메일 템플릿도 빌드하도록 nest-cli.json 수정
3) JWT와 Magic-login에 사용되는 secret key를 .env로 옮김
    - JWT_SECRET
    - MAGIC_SECRET