### PR TITLE
feat: 해시태그 모듈 생성 및 course 검색기능 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { AnswerModule } from './modules/answer/answer.module';
 import { LearningModule } from './modules/learning/learning.module';
 import { CompleteModule } from './modules/complete/complete.module';
 import { BannerModule } from './modules/banner/banner.module';
+import { HashtagModule } from './modules/hashtag/hashtag.module';
 
 @Module({
 	imports: [
@@ -45,6 +46,7 @@ import { BannerModule } from './modules/banner/banner.module';
 		LearningModule,
 		CompleteModule,
 		BannerModule,
+		HashtagModule,
 	],
 	controllers: [AppController],
 	providers: [AppService],

--- a/src/modules/course/course.service.ts
+++ b/src/modules/course/course.service.ts
@@ -47,6 +47,8 @@ export class CourseService {
 			});
 		}
 
+		const length = await courses.getCount();
+
 		courses = await courses
 			.offset(perPage * (page - 1))
 			.limit(perPage)
@@ -88,7 +90,7 @@ export class CourseService {
 			});
 		});
 
-		return courses;
+		return { length, courses };
 	}
 
 	async getCategories() {

--- a/src/modules/hashtag/hashtag.controller.spec.ts
+++ b/src/modules/hashtag/hashtag.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HashtagController } from './hashtag.controller';
+import { HashtagService } from './hashtag.service';
+
+describe('HashtagController', () => {
+  let controller: HashtagController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HashtagController],
+      providers: [HashtagService],
+    }).compile();
+
+    controller = module.get<HashtagController>(HashtagController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/hashtag/hashtag.controller.ts
+++ b/src/modules/hashtag/hashtag.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { HashtagService } from './hashtag.service';
+
+@Controller('hashtag')
+export class HashtagController {
+	constructor(private readonly hashtagService: HashtagService) {}
+
+	@Get()
+	getHashtags() {
+		return this.hashtagService.getHashtags();
+	}
+}

--- a/src/modules/hashtag/hashtag.module.ts
+++ b/src/modules/hashtag/hashtag.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HashtagService } from './hashtag.service';
+import { HashtagController } from './hashtag.controller';
+
+@Module({
+  controllers: [HashtagController],
+  providers: [HashtagService]
+})
+export class HashtagModule {}

--- a/src/modules/hashtag/hashtag.service.spec.ts
+++ b/src/modules/hashtag/hashtag.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HashtagService } from './hashtag.service';
+
+describe('HashtagService', () => {
+  let service: HashtagService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HashtagService],
+    }).compile();
+
+    service = module.get<HashtagService>(HashtagService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/hashtag/hashtag.service.ts
+++ b/src/modules/hashtag/hashtag.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { HashtagEntity } from 'src/entities/hashtag.entity';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class HashtagService {
+	constructor(private dataSource: DataSource) {}
+
+	async getHashtags() {
+		return await this.dataSource.getRepository(HashtagEntity).find();
+	}
+}


### PR DESCRIPTION
- 전체 해시태그를 돌려주는 엔드포인트 생성
- course 검색 시 검색된 전체 강의 개수를 포함하도록 변경