### PR TITLE
feat: 강의 시청 시 킹고코인 지급 로직 추가 (런칭 이벤트용) 및 수강률 반환 api 구현

### DIFF
--- a/src/entities/launching-event.entity.ts
+++ b/src/entities/launching-event.entity.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, OneToOne, PrimaryGeneratedColumn, JoinColumn } from 'typeorm';
+import { UserEntity } from './user.entity';
+
+@Entity()
+class LauchingEvent {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToOne(() => UserEntity)
+    @JoinColumn()
+    user: number;
+
+    @Column()
+    isProcessed: boolean
+
+}
+
+export { LauchingEvent as LaunchingEventEntity }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -41,6 +41,12 @@ class User {
 
 	@OneToMany(() => CourseEntity, (course) => course.instructor)
 	courses: CourseEntity[];
+
+	@Column({default: 0})
+	watchedLecturesCount: number;
+
+	@Column({default: 0})
+	commentsCount: number
 }
 
 export { User as UserEntity };

--- a/src/modules/history/history.controller.ts
+++ b/src/modules/history/history.controller.ts
@@ -10,13 +10,20 @@ import { ApiHistory } from './history.swagger';
 @ApiTags('History')
 @Controller('history')
 export class HistoryController {
-	constructor(private historyService: HistoryService) {}
-
+	constructor(private historyService: HistoryService) { }
+	
 	@Get()
 	@UseGuards(RolesGuard([Role.USER]))
 	@ApiHistory.getHistories()
 	getByUser(@User() user: ReqUser) {
 		return this.historyService.getByUser(user);
+	}
+	
+	@Get('/lectures/notFinished')
+	@UseGuards(RolesGuard([Role.USER]))
+	@ApiHistory.getNotFinishedLecture()
+	getNotFinishedGroupByCourse(@User() user: ReqUser) {
+		return this.historyService.getNotFinishedGroupByCourse(user);
 	}
 
 	@Get('lectures/:lectureId')
@@ -32,3 +39,4 @@ export class HistoryController {
 		return this.historyService.update(dto, user);
 	}
 }
+

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { HistoryService } from './history.service';
 import { HistoryController } from './history.controller';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
+	imports: [HttpModule],
 	controllers: [HistoryController],
 	providers: [HistoryService],
 	exports: [HistoryService],

--- a/src/modules/history/history.service.ts
+++ b/src/modules/history/history.service.ts
@@ -148,13 +148,14 @@ export class HistoryService {
 						})
 						.execute();
 					const transaction = await this.dataSource.getRepository(LaunchingEventEntity).findOne({
-						where: {user: user.id}
+						where: { user: user.id }
 					});
-					/*await this.httpService.post('https://kingocoin.cs.skku.edu/api/thrid-party/point/send?transactionId=' + transaction.id, {
+					await this.httpService.post('https://kingocoin.cs.skku.edu/api/thrid-party/point/send', {
 						email: user.email,
+						transactionId: transaction.id,
 						description: "명륜당 영상시청",
 						point: 400
-					});*/
+					});
 				}
 			}
 		}

--- a/src/modules/history/history.service.ts
+++ b/src/modules/history/history.service.ts
@@ -68,6 +68,22 @@ export class HistoryService {
 		});
 	}
 
+	async getNotFinishedGroupByCourse(user: ReqUser) {
+		return await this.dataSource.getRepository(History)
+			.createQueryBuilder("history")
+			.leftJoinAndSelect("history.lecture", "lecture")
+			.leftJoinAndSelect("lecture.course", "course")
+			.select("course.id", "courseId")
+			.addSelect("course.title", "courseTitle")
+			.addSelect("COUNT(*)", "notFinishedLecture")
+			.where("history.userId = :userId", { userId: user.id })
+			.andWhere("history.isFinished = :isFinished", { isFinished: false })
+			.groupBy("course.id")
+			.getRawMany();
+	}
+
+
+
 	async update(dto: UpdateHistoryDto, user: ReqUser): Promise<HttpResponse> {
 		const { lectureId, lastTime } = dto;
 		const historyRepository = this.dataSource.getRepository(History);

--- a/src/modules/history/history.service.ts
+++ b/src/modules/history/history.service.ts
@@ -1,3 +1,4 @@
+import { HttpService } from '@nestjs/axios';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { HttpResponse, status } from 'src/configs/etc/http-response.config';
 import { History } from 'src/entities/history.entity';
@@ -9,7 +10,10 @@ import { UpdateHistoryDto } from './dto/update-history.dto';
 
 @Injectable()
 export class HistoryService {
-	constructor(private dataSource: DataSource) { }
+	constructor(
+		private dataSource: DataSource,
+		private readonly httpService: HttpService
+	) { }
 
 	async getByUser(user: ReqUser): Promise<History[]> {
 		return await this.dataSource.getRepository(History).find({
@@ -135,7 +139,6 @@ export class HistoryService {
 					where: { user: user.id }
 				})
 				if (updatedUser.watchedLecturesCount === 1 && !eventInfo) {
-					console.log("킹고코인 API 호출이 필요합니다.");
 					await this.dataSource.createQueryBuilder()
 						.insert()
 						.into(LaunchingEventEntity)
@@ -144,6 +147,14 @@ export class HistoryService {
 							user: user.id
 						})
 						.execute();
+					const transaction = await this.dataSource.getRepository(LaunchingEventEntity).findOne({
+						where: {user: user.id}
+					});
+					/*await this.httpService.post('https://kingocoin.cs.skku.edu/api/thrid-party/point/send?transactionId=' + transaction.id, {
+						email: user.email,
+						description: "명륜당 영상시청",
+						point: 400
+					});*/
 				}
 			}
 		}

--- a/src/modules/history/history.swagger.ts
+++ b/src/modules/history/history.swagger.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 export const ApiHistory = {
 	getHistories() {
@@ -28,6 +28,26 @@ export const ApiHistory = {
 			}),
 			ApiCookieAuth(),
 		);
+	},
+	getNotFinishedLecture() {
+		return applyDecorators(
+			ApiOperation({
+				summary: '미수강 강의 개수 조회',
+				description: '강의 개수가 querybuilder에서 스트링으로만 반환되어 일단은 그대로 넘겨주었습니다.',
+			}),
+			ApiCookieAuth(),
+			ApiOkResponse({
+				schema: {
+					items: {
+						properties: {
+							courseId: { type: 'number' },
+							courseTitle: { type: 'string' },
+							notFinishedLecture: { type: 'string' },
+						}
+					}
+				}
+			})
+		)
 	},
 	createOrUpdateHistory() {
 		return applyDecorators(

--- a/src/modules/lecture/lecture.controller.ts
+++ b/src/modules/lecture/lecture.controller.ts
@@ -15,6 +15,11 @@ import { LectureService } from './lecture.service';
 export class LectureController {
 	constructor(private lectureService: LectureService) {}
 
+	@Get('count')
+	getAllLecturesGroupByCourse() {
+		return this.lectureService.getAllLecturesGroupByCourse();
+	}
+
 	@Get(':lectureId')
 	getLecturePathByLectureId(@Param('lectureId') id: number) {
 		return this.lectureService.getLecturePathByLectureId(id);

--- a/src/modules/lecture/lecture.service.ts
+++ b/src/modules/lecture/lecture.service.ts
@@ -4,17 +4,26 @@ import { LectureEntity } from 'src/entities/lecture.entity'
 
 @Injectable()
 export class LectureService {
-    constructor(private dataSource: DataSource) {}
+    constructor(private dataSource: DataSource) { }
 
-    async getLecturePathForTest(id:number) {
+    async getLecturePathForTest(id: number) {
         const url = process.env.S3_URL;
         const bucket = process.env.BUCKET;
         const path = 'lectures/'
-        
-        return url+bucket+path;
+
+        return url + bucket + path;
     }
 
-    async getLecturePathByLectureId(id:number)  {
+    async getAllLecturesGroupByCourse() {
+        return await this.dataSource.getRepository(LectureEntity)
+            .createQueryBuilder("lecture")
+            .select("courseId")
+            .addSelect("COUNT(*)", "lectures_count")
+            .groupBy("courseId")
+            .getRawMany();
+    }
+
+    async getLecturePathByLectureId(id: number) {
         return await this.dataSource
             .getRepository(LectureEntity)
             .find({
@@ -26,6 +35,6 @@ export class LectureService {
                     title: true,
                     filename: true,
                 },
-        })
+            })
     }
 }


### PR DESCRIPTION
- 코인 지급 기록용 lauching_event 테이블 생성
- 유저 엔티티에 시청 강좌 및 댓글 개수 컬럼 추가