### PR TITLE
fix: typeORM findOne() 관련 문제 수정

### DIFF
--- a/src/modules/history/history.service.ts
+++ b/src/modules/history/history.service.ts
@@ -146,9 +146,11 @@ export class HistoryService {
 				const updatedUser = await userRepository.findOne({
 					where: { id: user.id },
 				});
-				const eventInfo = await launchingEventRepository.findOne({
+
+				let eventInfo = await launchingEventRepository.findOne({
 					where: { user: user.id },
 				});
+				if (eventInfo.user !== user.id) eventInfo = undefined;
 
 				if (
 					updatedUser.watchedLecturesCount >= 1 &&


### PR DESCRIPTION
- typeORM의 findOne()이 where 조건에 맞는 레코드가 없는 경우, 첫 번째 레코드를 반환하던 문제를 수정하였습니다.